### PR TITLE
[CJS-8565] local/dev mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,4 @@ dist
 .wrangler/
 
 .DS_Store
+/.idea

--- a/templates/edge-delivery-starter/package.json
+++ b/templates/edge-delivery-starter/package.json
@@ -3,13 +3,13 @@
   "license": "Apache-2.0",
   "version": "0.0.0",
   "scripts": {
-    "deploy": "wrangler deploy",
-    "dev": "wrangler dev",
+    "deploy": "wrangler deploy --env prod",
+    "dev": "wrangler dev --env dev",
     "start": "wrangler dev",
     "cf-typegen": "wrangler types"
   },
   "dependencies": {
-    "@optimizely/edge-delivery": "^0.0.7"
+    "@optimizely/edge-delivery": "^0.0.12"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240502.0",

--- a/templates/edge-delivery-starter/src/index.ts
+++ b/templates/edge-delivery-starter/src/index.ts
@@ -11,13 +11,14 @@
  * Learn more at https://developers.cloudflare.com/workers/
  */
 
-import { applyExperiments } from '@optimizely/edge-delivery';
+import { applyExperiments, Options } from '@optimizely/edge-delivery';
 
 interface Env {
     SNIPPET_ID: string;
-    DEV_URL: string;
+    environment: 'dev' | 'prod'
+    dev_host?: string;
 }
- 
+
 export default {
     async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
         return await handleRequest(request, env, ctx);
@@ -26,14 +27,15 @@ export default {
 
 async function handleRequest(request: Request, env: Env, ctx: ExecutionContext) {
     // Configure all the options to pass to Optimizely
-    const options = {
+    const options: Options = {
         "snippetId": env.SNIPPET_ID,
-        "devUrl": env.DEV_URL,
+        environment: env.environment,
+        dev_host: env.dev_host
     };
 
     // Make experiment decisions based on the request information
     // Apply those changes to the control
-    // Any decisions or changes that cannot be made here are packaged together 
-    // and added to the <head> element for execution on the browser 
+    // Any decisions or changes that cannot be made here are packaged together
+    // and added to the <head> element for execution on the browser
     return await applyExperiments(request, ctx, options);
 }

--- a/templates/edge-delivery-starter/wrangler.toml
+++ b/templates/edge-delivery-starter/wrangler.toml
@@ -5,6 +5,10 @@ main = "src/index.ts"
 compatibility_date = "2024-05-02"
 compatibility_flags = ["nodejs_compat"]
 
-[vars]
+[env.dev.vars]
 SNIPPET_ID = "29061560280"
-DEV_URL = "https://example.com/"
+environment = 'dev'
+dev_host = 'example.com'
+
+[env.prod.vars]
+environment = 'prod'


### PR DESCRIPTION
## Summary

- the better way to work in local/dev is knowing in what environment we are. in cloudflare there is not a way to know that automatically. so the customer have to set the `enviroment` variable in the `wrangler.toml`.
- if the developer is en `dev` mode and the `dev_host` is not setted up. the default value is example.com 
- costumers are able to create variables per environment adding `[env.<environment>.vars]`. this variables don't inherits from other environments. thats why the customer have to define the variables on each environment.
- to run the starter with the environment variables. the customer have to add a `command` in the `package.json` with the environment flag `--env=<environment>`.
- to reduce mistakes in the url. added host, upstream_protocol, upstream_port, upstream_pathname variables. and we create the url.
- to have a better developer experience. the developer is able to import the `Options` type to get intellisense creating the `const options: Options = {` object 

Note: in the ticket you can find more info about local development in cloudflare workers

## Jira

- [CJS-8565](https://jira.sso.episerver.net/browse/CJS-8565)